### PR TITLE
Add interactive globe demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# DuckxStreet
+# DuckxStreet Globe Demo
+
+This repository contains a simple static web page that displays an interactive 3D globe using [globe.gl](https://globe.gl/).
+
+## Usage
+
+Open `index.html` in a modern web browser with internet access. The globe can be rotated and zoomed. Clicking on a highlighted country will display a modal with placeholder Instagram posts for that country. Click on a post to open the original link in a new tab.
+
+The demo uses Tailwind CSS for styling and a small hard-coded dataset located in `posts.js`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Interactive Globe</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/globe.gl"></script>
+  <script src="https://unpkg.com/topojson-client@3"></script>
+</head>
+<body class="bg-gray-900 text-white">
+  <div id="globe-container" class="w-full h-screen"></div>
+  <div id="modal" class="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center hidden">
+    <div class="bg-white text-black max-w-lg w-full mx-4 rounded shadow-lg overflow-y-auto max-h-full">
+      <div class="flex justify-between items-center p-4 border-b">
+        <h2 id="modal-title" class="text-xl font-semibold"></h2>
+        <button id="close-modal" class="text-gray-700">&times;</button>
+      </div>
+      <div id="modal-content" class="p-4 grid grid-cols-1 sm:grid-cols-2 gap-4"></div>
+    </div>
+  </div>
+  <script src="posts.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,68 @@
+const worldUrl = 'https://unpkg.com/world-atlas@2/countries-110m.json';
+const earthTexture = 'https://unpkg.com/three-globe/example/img/earth-dark.jpg';
+
+const Globe = window.Globe; // from globe.gl CDN
+
+const world = Globe()
+  .globeImageUrl(earthTexture)
+  .backgroundColor('#000')
+  .showAtmosphere(true)
+  .atmosphereColor('#3a228a')
+  .atmosphereAltitude(0.25);
+
+const container = document.getElementById('globe-container');
+container.appendChild(world());
+
+fetch(worldUrl)
+  .then(res => res.json())
+  .then(worldData => {
+    const countries = window.topojson.feature(worldData, worldData.objects.countries).features;
+    world
+      .polygonsData(countries)
+      .polygonCapColor(() => 'rgba(255, 255, 255, 0.1)')
+      .polygonSideColor(() => 'rgba(0, 100, 0, 0.15)')
+      .polygonStrokeColor(() => '#111')
+      .onPolygonClick(country => showCountryPosts(country));
+
+    // Add markers for countries with posts
+    const markers = postsData.reduce((acc, post) => {
+      acc[post.country] = true;
+      return acc;
+    }, {});
+    const markerFeatures = countries.filter(c => markers[c.properties.name]);
+    world
+      .pointsData(markerFeatures)
+      .pointAltitude(0.1)
+      .pointColor(() => 'orange');
+  });
+
+function showCountryPosts(countryFeature) {
+  const name = countryFeature.properties.name;
+  const posts = getPostsByCountry(name);
+  if (!posts.length) return;
+
+  const modal = document.getElementById('modal');
+  const title = document.getElementById('modal-title');
+  const content = document.getElementById('modal-content');
+
+  title.textContent = countryFeature.properties.name;
+  content.innerHTML = '';
+  posts.forEach(p => {
+    const item = document.createElement('div');
+    item.className = 'cursor-pointer';
+    item.innerHTML = `
+      <img src="${p.thumbnail}" alt="${p.caption}" class="w-full h-auto rounded" />
+      <p class="mt-2 text-sm">${p.caption}</p>
+    `;
+    item.addEventListener('click', () => {
+      window.open(p.url, '_blank');
+    });
+    content.appendChild(item);
+  });
+
+  modal.classList.remove('hidden');
+}
+
+document.getElementById('close-modal').addEventListener('click', () => {
+  document.getElementById('modal').classList.add('hidden');
+});

--- a/posts.js
+++ b/posts.js
@@ -1,0 +1,38 @@
+const postsData = [
+  {
+    id: 1,
+    country: 'United States of America',
+    url: 'https://www.instagram.com/p/US_SAMPLE/',
+    thumbnail: 'https://via.placeholder.com/150',
+    caption: 'Amazing view from the US',
+    type: 'image'
+  },
+  {
+    id: 2,
+    country: 'France',
+    url: 'https://www.instagram.com/p/FR_SAMPLE/',
+    thumbnail: 'https://via.placeholder.com/150',
+    caption: 'Bonjour from France',
+    type: 'image'
+  },
+  {
+    id: 3,
+    country: 'Japan',
+    url: 'https://www.instagram.com/p/JP_SAMPLE/',
+    thumbnail: 'https://via.placeholder.com/150',
+    caption: 'Greetings from Japan',
+    type: 'image'
+  },
+  {
+    id: 4,
+    country: 'United States of America',
+    url: 'https://www.instagram.com/p/US_SAMPLE2/',
+    thumbnail: 'https://via.placeholder.com/150',
+    caption: 'Another shot from the US',
+    type: 'image'
+  }
+];
+
+function getPostsByCountry(name) {
+  return postsData.filter(p => p.country === name);
+}


### PR DESCRIPTION
## Summary
- build a static web page showing an interactive 3D globe
- display modal with placeholder Instagram posts when clicking a country
- add minimal Tailwind styling and example dataset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684efcc9e62883218b55f9e3dc2cc62b