### PR TITLE
Add link to DuckxStreet Instagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ This repository contains a simple static web page that displays an interactive 2
 Open `index.html` in a modern web browser with internet access. The map allows you to click on highlighted countries to display a modal with placeholder Instagram posts. Click on a post to open the original link in a new tab.
 
 The demo uses Tailwind CSS for styling and a small hard-coded dataset located in `posts.js`.
+
+## Social Media
+
+Follow us on [Instagram](https://www.instagram.com/duckxstreet/).

--- a/index.html
+++ b/index.html
@@ -19,6 +19,11 @@
       <div id="modal-content" class="p-4 grid grid-cols-1 sm:grid-cols-2 gap-4"></div>
     </div>
   </div>
+  <footer class="absolute bottom-0 left-0 right-0 bg-gray-800 text-center p-4">
+    <a href="https://www.instagram.com/duckxstreet/" target="_blank" class="text-blue-400 hover:underline">
+      Follow us on Instagram
+    </a>
+  </footer>
   <script src="posts.js"></script>
   <script src="main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add official Instagram link in the footer of `index.html`
- mention Instagram account in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684effd44cb48321b6a73d291be234ea